### PR TITLE
Compile portmidi with ALSA support on Linux.

### DIFF
--- a/dep/Makefile
+++ b/dep/Makefile
@@ -4,6 +4,10 @@ LOCAL = $(PWD)
 # Arch-specifics
 include ../arch.mk
 
+ifeq ($(ARCH),lin)
+	CFLAGS += -DPMALSA
+endif
+
 ifeq ($(ARCH),mac)
 	export CFLAGS = -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk \
 		-mmacosx-version-min=10.7

--- a/dep/Makefile
+++ b/dep/Makefile
@@ -89,7 +89,7 @@ $(libzip):
 
 $(portmidi):
 	git clone https://github.com/AndrewBelt/portmidi.git $@
-	cd $@ && $(CMAKE) . -DCMAKE_INSTALL_PREFIX="$(LOCAL)"
+	cd $@ && $(CMAKE) . -DCMAKE_INSTALL_PREFIX="$(LOCAL)" -DCMAKE_BUILD_TYPE=Release
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
 

--- a/dep/Makefile
+++ b/dep/Makefile
@@ -4,10 +4,6 @@ LOCAL = $(PWD)
 # Arch-specifics
 include ../arch.mk
 
-ifeq ($(ARCH),lin)
-	CFLAGS += -DPMALSA
-endif
-
 ifeq ($(ARCH),mac)
 	export CFLAGS = -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk \
 		-mmacosx-version-min=10.7


### PR DESCRIPTION
On Linux, compiling portmidi with ALSA support might be preferable. Thix should fix #95.