### PR TITLE
[WIP] midi interface revamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,22 @@ ifeq ($(ARCH), lin)
 	TARGET = Rack
 endif
 
+ifeq ($(ARCH), lin)
+	SOURCES += ext/osdialog/osdialog_gtk2.c
+	CFLAGS += $(shell pkg-config --cflags gtk+-2.0)
+	LDFLAGS += -rdynamic \
+		-lpthread -lGL -ldl \
+		$(shell pkg-config --libs gtk+-2.0) \
+		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip -lportaudio -lrtmidi
+	TARGET = Rack
+endif
+
 ifeq ($(ARCH), mac)
 	SOURCES += ext/osdialog/osdialog_mac.m
 	CXXFLAGS += -DAPPLE -stdlib=libc++
 	LDFLAGS += -stdlib=libc++ -lpthread -ldl \
 		-framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo \
-		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip -lportaudio -lportmidi
+		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip -lportaudio -lrtmidi
 	TARGET = Rack
 endif
 
@@ -32,7 +42,29 @@ ifeq ($(ARCH), win)
 	LDFLAGS += -static-libgcc -static-libstdc++ -lpthread \
 		-Wl,--export-all-symbols,--out-implib,libRack.a -mwindows \
 		-lgdi32 -lopengl32 -lcomdlg32 -lole32 \
-		-Ldep/lib -lglew32 -lglfw3dll -lcurl -lzip -lportaudio_x64 -lportmidi \
+		-Ldep/lib -lglew32 -lglfw3dll -lcurl -lzip -lportaudio_x64 -lrtmidi \
+		-Wl,-Bstatic -ljansson -lsamplerate
+	TARGET = Rack.exe
+	OBJECTS = Rack.res
+endif
+
+
+all: $(TARGET)
+ifeq ($(ARCH), mac)
+	SOURCES += ext/osdialog/osdialog_mac.m
+	CXXFLAGS += -DAPPLE -stdlib=libc++
+	LDFLAGS += -stdlib=libc++ -lpthread -ldl \
+		-framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo \
+		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip -lportaudio -lrtmidi
+	TARGET = Rack
+endif
+
+ifeq ($(ARCH), win)
+	SOURCES += ext/osdialog/osdialog_win.c
+	LDFLAGS += -static-libgcc -static-libstdc++ -lpthread \
+		-Wl,--export-all-symbols,--out-implib,libRack.a -mwindows \
+		-lgdi32 -lopengl32 -lcomdlg32 -lole32 \
+		-Ldep/lib -lglew32 -lglfw3dll -lcurl -lzip -lportaudio_x64 -lrtmidi \
 		-Wl,-Bstatic -ljansson -lsamplerate
 	TARGET = Rack.exe
 	OBJECTS = Rack.res
@@ -98,7 +130,7 @@ ifeq ($(ARCH), mac)
 	cp dep/lib/libcurl.4.dylib $(BUNDLE)/Contents/MacOS/
 	cp dep/lib/libzip.5.dylib $(BUNDLE)/Contents/MacOS/
 	cp dep/lib/libportaudio.2.dylib $(BUNDLE)/Contents/MacOS/
-	cp dep/lib/libportmidi.dylib $(BUNDLE)/Contents/MacOS/
+	cp dep/lib/librtmidi.dylib $(BUNDLE)/Contents/MacOS/
 
 	install_name_tool -change /usr/local/lib/libGLEW.2.1.0.dylib @executable_path/libGLEW.2.1.0.dylib $(BUNDLE)/Contents/MacOS/Rack
 	install_name_tool -change lib/libglfw.3.dylib @executable_path/libglfw.3.dylib $(BUNDLE)/Contents/MacOS/Rack
@@ -107,7 +139,7 @@ ifeq ($(ARCH), mac)
 	install_name_tool -change $(PWD)/dep/lib/libcurl.4.dylib @executable_path/libcurl.4.dylib $(BUNDLE)/Contents/MacOS/Rack
 	install_name_tool -change $(PWD)/dep/lib/libzip.5.dylib @executable_path/libzip.5.dylib $(BUNDLE)/Contents/MacOS/Rack
 	install_name_tool -change $(PWD)/dep/lib/libportaudio.2.dylib @executable_path/libportaudio.2.dylib $(BUNDLE)/Contents/MacOS/Rack
-	install_name_tool -change @rpath/libportmidi.dylib @executable_path/libportmidi.dylib $(BUNDLE)/Contents/MacOS/Rack
+	install_name_tool -change @rpath/librtmidi.dylib @executable_path/librtmidi.dylib $(BUNDLE)/Contents/MacOS/Rack
 
 	otool -L $(BUNDLE)/Contents/MacOS/Rack
 
@@ -126,7 +158,7 @@ ifeq ($(ARCH), win)
 	cp dep/bin/glfw3.dll dist/Rack/
 	cp dep/bin/libcurl-4.dll dist/Rack/
 	cp dep/bin/libjansson-4.dll dist/Rack/
-	cp dep/bin/libportmidi.dll dist/Rack/
+	cp dep/bin/librtmidi.dll dist/Rack/
 	cp dep/bin/libsamplerate-0.dll dist/Rack/
 	cp dep/bin/libzip-5.dll dist/Rack/
 	cp dep/bin/portaudio_x64.dll dist/Rack/
@@ -144,7 +176,7 @@ ifeq ($(ARCH), lin)
 	cp dep/lib/libcurl.so.4 dist/Rack/
 	cp dep/lib/libzip.so.5 dist/Rack/
 	cp dep/lib/libportaudio.so.2 dist/Rack/
-	cp dep/lib/libportmidi.so dist/Rack/
+	cp dep/lib/librtmidi.so dist/Rack/
 	mkdir -p dist/Rack/plugins
 	cp -R plugins/Fundamental/dist/Fundamental dist/Rack/plugins/
 endif

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifeq ($(ARCH), lin)
 	LDFLAGS += -rdynamic \
 		-lpthread -lGL -ldl \
 		$(shell pkg-config --libs gtk+-2.0) \
-		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip -lportaudio -lportmidi
+		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip -lportaudio -lrtmidi
 	TARGET = Rack
 endif
 

--- a/dep/Makefile
+++ b/dep/Makefile
@@ -1,4 +1,3 @@
-
 LOCAL = $(shell pwd)
 
 # Arch-specifics
@@ -28,7 +27,7 @@ ifeq ($(ARCH),lin)
 	libsamplerate = lib/libsamplerate.so
 	libcurl = lib/libcurl.so
 	libzip = lib/libzip.so
-	portmidi = lib/libportmidi.so
+	rtmidi = lib/librtmidi.so
 	portaudio = lib/libportaudio.so
 endif
 
@@ -39,7 +38,7 @@ ifeq ($(ARCH),mac)
 	libsamplerate = lib/libsamplerate.dylib
 	libcurl = lib/libcurl.dylib
 	libzip = lib/libzip.dylib
-	portmidi = lib/libportmidi.dylib
+	rtmidi = lib/librtmidi.dylib
 	portaudio = lib/libportaudio.dylib
 endif
 
@@ -50,14 +49,14 @@ ifeq ($(ARCH),win)
 	libsamplerate = bin/libsamplerate-0.dll
 	libcurl = bin/libcurl-4.dll
 	libzip = bin/libzip-5.dll
-	portmidi = bin/libportmidi.dll
+    rtmidi = bin/rtmidi.dll
 	portaudio = bin/libportaudio_x64.dll
 endif
 
 
 .NOTPARALLEL:
 
-all: $(glew) $(glfw) $(jansson) $(libsamplerate) $(libcurl) $(libzip) $(portmidi) $(portaudio)
+all: $(glew) $(glfw) $(jansson) $(libsamplerate) $(libcurl) $(libzip) $(rtmidi) $(portaudio)
 	@echo ""
 	@echo "#######################################"
 	@echo "# Built all dependencies successfully #"
@@ -114,11 +113,11 @@ $(libzip):
 	$(MAKE) -C libzip-1.2.0
 	$(MAKE) -C libzip-1.2.0 install
 
-$(portmidi):
-	git clone https://github.com/AndrewBelt/portmidi.git portmidi
-	cd portmidi && $(CMAKE) . -DCMAKE_INSTALL_PREFIX="$(LOCAL)" -DCMAKE_BUILD_TYPE=Release
-	$(MAKE) -C portmidi
-	$(MAKE) -C portmidi install
+$(rtmidi):
+	git clone https://github.com/thestk/rtmidi.git rtmidi
+	cd rtmidi && ./autogen.sh && ./configure --prefix="$(LOCAL)"
+	$(MAKE) -C rtmidi
+	$(MAKE) -C rtmidi install
 
 $(portaudio):
 ifeq ($(ARCH),win)

--- a/src/core/MidiInterface.cpp
+++ b/src/core/MidiInterface.cpp
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <list>
 #include <algorithm>
-#include <rtmidi/RtMidi.h>
+#include "rtmidi/RtMidi.h"
 #include "core.hpp"
 #include "gui.hpp"
 #include "../../include/engine.hpp"
@@ -40,7 +40,7 @@ struct MidiInterface : Module {
 
 	MidiInterface() : Module(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS) {
         try {
-            midiIn = new RtMidiIn();
+            midiIn = new RtMidiIn(RtMidi::UNSPECIFIED, "VCVRack");
         }
         catch ( RtMidiError &error ) {
             fprintf(stderr,"Failed to create RtMidiIn: %s\n", error.getMessage().c_str());
@@ -145,7 +145,7 @@ void MidiInterface::setPortId(int portId) {
 
 	// Open new port
 	if (portId >= 0) {
-        midiIn->openPort(portId);
+        midiIn->openPort(portId, "Midi Interface");
 	}
 	this->portId = portId;
 }
@@ -185,7 +185,7 @@ void MidiInterface::processMidi(std::vector<unsigned char> msg) {
     int data1 = msg[1];
     int data2 = msg[2];
 
-    //    fprintf(stderr, "channel %d status %d data1 %d data2 %d\n", channel, status, data1,data2);
+    //fprintf(stderr, "channel %d status %d data1 %d data2 %d\n", channel, status, data1,data2);
 
 	// Filter channels
 	if (this->channel >= 0 && this->channel != channel)


### PR DESCRIPTION
This implements the midi interface revamp as described in #81 

- [x] Compare rtMidi/portmidi

**Conclusion**: Switching to rtMidi fixes #62 and allows using multiple interfaces on a single port without any additional code. (As far as I can tell, portmidi would require an additional wrapper to handle multiple interfaces for a portmidi stream.)

- [x]  Update Makefile to switch from portmidi to rtMidi
**Note:** Works on linux, but this should be tested on other systems to assure it works (I'm not fluent with Makefiles, so I guessed. This might work or not, we'll see ) 

- [x] Switch MidiInterface implementation to rtMidi

# List from #81
- [ ] MIDI-to-CV
	- [ ] 1V/oct, gate, velocity, pitchwheel, mod, volume, aftertouch outputs
	- [ ] MIDI clock output, start/stop gate, song reset outputs
	- [ ] LED for each output
	- [x] Be able to use the two interfaces on the same port, useful for MIDI channels
- [ ] Quad MIDI-to-CV
	- [ ] polyphonic voice asignment modes (rotate, reset, reasign)
	- [ ] 4x 1V/oct, 4x gate, 4x velocity outputs
	- [ ] pitchwheel, mod, volume outputs
	- [ ] LED for each gate
- [ ]  MIDI CC-to-CV
	- [ ] grid of 16 CC voltage outputs
	- [ ] select source CC channel for each port by clicking the dropdown on each one
	- [ ] LEDs for each output
- [ ] CV-to-MIDI
	- [ ] 1V/oct, gate, velocity, pitchwheel, mod inputs
	- [ ] MIDI clock, start/stop gate, song reset inputs
	- [ ] LED for each input