### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Rack's dependencies (GLEW, glfw, etc) do not need to be installed on your system
 
 ### Mac
 
-Install [Xcode](https://developer.apple.com/xcode/) or *command line developer tools* with `xcode-select --install`.
+Install [Xcode](https://developer.apple.com/xcode/)
 Install [CMake](https://cmake.org/) and wget, preferably from [Homebrew](https://brew.sh/).
 
 ### Windows


### PR DESCRIPTION
Xcode-cli tools no longer enough...?

```
checking for nanosleep... yes
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
```
Ref: https://github.com/VCVRack/Rack/issues/122