### PR TITLE
fixed gate val on note off in MidiTriggerToCV

### DIFF
--- a/src/core/MidiTriggerToCV.cpp
+++ b/src/core/MidiTriggerToCV.cpp
@@ -110,7 +110,7 @@ void MIDITriggerToCVInterface::processMidi(std::vector<unsigned char> msg) {
 	if (status == 0x8) { // note off
 		for (int i = 0; i < NUM_OUTPUTS; i++) {
 			if (data1 == trigger[i].num) {
-				trigger[i].val = data2;
+				trigger[i].val = 0;
 			}
 		}
 		return;


### PR DESCRIPTION
Not using data2 here because some implementations do not send a zero velocity for note off.  As discussed here https://www.facebook.com/groups/vcvrack/permalink/137757963551023/

My original video is in the facebook post.  My video of the fix working is here: 
https://www.youtube.com/watch?v=hD70UqUqoV4&feature=youtu.be