### PR TITLE
Clean up libRack.a file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ endif
 
 
 clean:
+	rm -fv libRack.a
 	rm -rfv $(TARGET) build dist
 
 # For Windows resources


### PR DESCRIPTION
`make clean` does currently not remove the file `libRack.a` that is created as part of the build. `git` shows it as `untracked` in the repository.