### PR TITLE
Cross-Compilation (linux to MinGW 64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@ FLAGS += \
 SOURCES = $(wildcard src/*.cpp src/*/*.cpp) \
 	ext/nanovg/src/nanovg.c
 
+CORE_LDFLAGS = -lrtaudio -lrtmidi
+
+ifdef WITHOUT_CORE
+	SOURCES := $(filter-out src/core/%,$(SOURCES))
+	FLAGS += -DWITHOUT_CORE
+	CORE_LDFLAGS =
+endif
 
 include arch.mk
 
@@ -14,7 +21,7 @@ ifeq ($(ARCH), lin)
 	LDFLAGS += -rdynamic \
 		-lpthread -lGL -ldl \
 		$(shell pkg-config --libs gtk+-2.0) \
-		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip -lrtaudio -lrtmidi
+		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip $(CORE_LDFLAGS)
 	TARGET = Rack
 endif
 
@@ -23,7 +30,7 @@ ifeq ($(ARCH), mac)
 	CXXFLAGS += -DAPPLE -stdlib=libc++
 	LDFLAGS += -stdlib=libc++ -lpthread -ldl \
 		-framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo \
-		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip -lrtaudio -lrtmidi
+		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip $(CORE_LDFLAGS)
 	TARGET = Rack
 	BUNDLE = dist/$(TARGET).app
 endif
@@ -33,7 +40,7 @@ ifeq ($(ARCH), win)
 	LDFLAGS += -static-libgcc -static-libstdc++ -lpthread \
 		-Wl,--export-all-symbols,--out-implib,libRack.a -mwindows \
 		-lgdi32 -lopengl32 -lcomdlg32 -lole32 \
-		-Ldep/lib -lglew32 -lglfw3dll -lcurl -lzip -lrtaudio -lrtmidi \
+		-Ldep/lib -lglew32 -lglfw3dll -lcurl -lzip $(CORE_LDFLAGS) \
 		-Wl,-Bstatic -ljansson -lsamplerate
 	TARGET = Rack.exe
 	OBJECTS = Rack.res

--- a/dep/Makefile
+++ b/dep/Makefile
@@ -71,12 +71,21 @@ endif
 
 .NOTPARALLEL:
 
+ifdef WITHOUT_CORE
+all: $(glew) $(glfw) $(jansson) $(libsamplerate) $(libcurl) $(libzip)
+	@echo ""
+	@echo "#######################################"
+	@echo "# Built dependencies successfully     #"
+	@echo "#######################################"
+	@echo ""
+else
 all: $(glew) $(glfw) $(jansson) $(libsamplerate) $(libcurl) $(libzip) $(rtmidi) $(rtaudio)
 	@echo ""
 	@echo "#######################################"
 	@echo "# Built all dependencies successfully #"
 	@echo "#######################################"
 	@echo ""
+endif
 
 $(glew):
 	$(WGET) https://github.com/nigels-com/glew/releases/download/glew-2.1.0/glew-2.1.0.tgz
@@ -84,6 +93,9 @@ $(glew):
 	$(MAKE) -C glew-2.1.0 glew.lib
 	# On Linux, default lib path is lib64, so change it back to lib.
 	$(MAKE) -C glew-2.1.0 GLEW_DEST="$(LOCAL)" LIBDIR="$(LOCAL)/lib" install
+ifeq ($(SYSTEM), linux-mingw64)
+	rm "$(LOCAL)/lib/libglew32.a" # broken file shadows the dll
+endif
 
 $(glfw):
 	cd glfw && $(CMAKE) . \
@@ -95,21 +107,21 @@ $(glfw):
 $(jansson):
 	$(WGET) http://www.digip.org/jansson/releases/jansson-2.10.tar.gz
 	$(UNTAR) jansson-2.10.tar.gz
-	cd jansson-2.10 && ./configure --prefix="$(LOCAL)"
+	cd jansson-2.10 && ./configure $(CFGFLAGS) --prefix="$(LOCAL)"
 	$(MAKE) -C jansson-2.10
 	$(MAKE) -C jansson-2.10 install
 
 $(libsamplerate):
 	$(WGET) http://www.mega-nerd.com/SRC/libsamplerate-0.1.9.tar.gz
 	$(UNTAR) libsamplerate-0.1.9.tar.gz
-	cd libsamplerate-0.1.9 && ./configure --prefix="$(LOCAL)" --disable-fftw --disable-sndfile
+	cd libsamplerate-0.1.9 && ./configure $(CFGFLAGS) --prefix="$(LOCAL)" --disable-fftw --disable-sndfile
 	$(MAKE) -C libsamplerate-0.1.9/src
 	$(MAKE) -C libsamplerate-0.1.9/src install
 
 $(libcurl):
 	$(WGET) https://github.com/curl/curl/releases/download/curl-7_56_0/curl-7.56.0.tar.gz
 	$(UNTAR) curl-7.56.0.tar.gz
-	cd curl-7.56.0 && ./configure --prefix="$(LOCAL)" \
+	cd curl-7.56.0 && ./configure $(CFGFLAGS) --prefix="$(LOCAL)" \
 		--disable-ftp --disable-file --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual \
 		--without-zlib --without-ssl --without-ca-bundle --without-ca-path --without-ca-fallback --without-libpsl --without-libmetalink --without-libssh2 --without-librtmp --without-winidn --without-libidn2 --without-nghttp2
 	$(MAKE) -C curl-7.56.0
@@ -118,14 +130,14 @@ $(libcurl):
 $(libzip):
 	$(WGET) https://nih.at/libzip/libzip-1.2.0.tar.gz
 	$(UNTAR) libzip-1.2.0.tar.gz
-	cd libzip-1.2.0 && ./configure --prefix="$(LOCAL)"
+	cd libzip-1.2.0 && ./configure $(CFGFLAGS) --prefix="$(LOCAL)"
 	$(MAKE) -C libzip-1.2.0
 	$(MAKE) -C libzip-1.2.0 install
 
 $(rtmidi):
 	$(WGET) http://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-3.0.0.tar.gz
 	$(UNTAR) rtmidi-3.0.0.tar.gz
-	cd rtmidi-3.0.0 && ./configure --prefix="$(LOCAL)"
+	cd rtmidi-3.0.0 && ./configure $(CFGFLAGS) --prefix="$(LOCAL)"
 	$(MAKE) -C rtmidi-3.0.0
 	$(MAKE) -C rtmidi-3.0.0 install
 

--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -10,8 +10,8 @@
 #endif
 
 #if ARCH_WIN
-#include <Windows.h>
-#include <Shlobj.h>
+#include <windows.h>
+#include <shlobj.h>
 #endif
 
 #if ARCH_LIN

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -248,11 +248,14 @@ static void refreshPurchase(json_t *pluginJ) {
 
 void pluginInit() {
 	tagsInit();
+
+#ifndef WITHOUT_CORE
 	// Load core
 	// This function is defined in core.cpp
 	Plugin *coreManufacturer = new Plugin();
 	init(coreManufacturer);
 	gPlugins.push_back(coreManufacturer);
+#endif
 
 	// Load plugins from global directory
 	std::string globalPlugins = assetGlobal("plugins");


### PR DESCRIPTION
(This is WIP and for documenting progress so far)

I am running arch and installed these packages:

    mingw-w64-binutils 2.29-1
    mingw-w64-cmake 1-18
    mingw-w64-crt 5.0.3-1
    mingw-w64-gcc 7.2.0-1
    mingw-w64-headers 5.0.3-1
    mingw-w64-pkg-config 2-3
    mingw-w64-winpthreads 5.0.3-1
    mingw-w64-glew 2.1.0-1

Compiling deps:
- can't get GLEW to work but seems to link against mingw-w64-glew package
- rtaudio and rtmidi also fail in random ways
- rest can be built using:

      make ARCH=win CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ LD=x86_64-w64-mingw32-ld CMAKE=x86_64-w64-mingw32-cmake CONFIGURE="./configure --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --enable-shared --enable-static"

(possibly needs `PATH=/usr/x86_64-w64-mingw32/bin/:$PATH`)