### PR TITLE
Update documentation for required dependencies for Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install [CMake](https://cmake.org/) (for some of Rack's dependencies) and wget, 
 Install [MSYS2](http://www.msys2.org/) and launch the mingw64 shell (not the default msys2 shell).
 Install build dependencies with the pacman package manger.
 
-	pacman -S git make tar unzip mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake
+	pacman -S git make tar unzip mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake automake autoconf libtool pkgconfig mingw-w64-x86_64-fftw
 
 ### Linux
 


### PR DESCRIPTION
The following packages are required to build the new `libspeexdsp` dependency on Windows:

```
automake
autoconf
libtool
pkgconfig
mingw-w64-x86_64-fftw
```

Wraps up #547.