### PR TITLE
Fix make debug for Windows platform.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ifeq ($(ARCH), mac)
 endif
 ifeq ($(ARCH), win)
 	# TODO get rid of the mingw64 path
-	env PATH=dep/bin:/mingw64/bin gdb -ex run ./Rack
+	env PATH="$(PATH)":dep/bin:/mingw64/bin gdb -ex run ./Rack
 endif
 
 perf: $(TARGET)


### PR DESCRIPTION
`make debug` does not work on Windows platform with the current `Makefile`. The `PATH` is overridden and the required binaries for invoking `gdb` are not found.