### PR TITLE
Consider adding sandboxing support to Rack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifeq ($(ARCH), mac)
 	CXXFLAGS += -DAPPLE -stdlib=libc++
 	LDFLAGS += -stdlib=libc++ -lpthread -ldl \
 		-framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo \
-		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip -lrtaudio -lrtmidi -lcrypto
+		-Ldep/lib -lGLEW -lglfw -ljansson -lsamplerate -lcurl -lzip -lrtaudio -lrtmidi -lcrypto -lsandbox
 	TARGET = Rack
 	BUNDLE = dist/$(TARGET).app
 endif
@@ -54,11 +54,6 @@ endif
 ifeq ($(ARCH), win)
 	# TODO get rid of the mingw64 path
 	env PATH=dep/bin:/mingw64/bin ./$<
-endif
-
-sandbox-run: $(TARGET)
-ifeq ($(ARCH), mac)
-	sandbox-exec -D RACK_HOME=$(PWD) -f ./Rack.sb `which sh` -c 'DYLD_FALLBACK_LIBRARY_PATH=dep/lib ./$<'                                                                      2 ↵  ✹ ✭sandbox ‹2.4.2›
 endif
 
 debug: $(TARGET)
@@ -97,6 +92,7 @@ ifeq ($(ARCH), mac)
 	mkdir -p $(BUNDLE)/Contents/Resources
 	cp Info.plist $(BUNDLE)/Contents/
 	cp -R LICENSE* res $(BUNDLE)/Contents/Resources
+	cp Rack.sb $(BUNDLE)/Contents/Resources
 
 	mkdir -p $(BUNDLE)/Contents/MacOS
 	cp Rack $(BUNDLE)/Contents/MacOS/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ FLAGS += \
 SOURCES = $(wildcard src/*.cpp src/*/*.cpp) \
 	ext/nanovg/src/nanovg.c
 
-
 include arch.mk
 
 ifeq ($(ARCH), lin)
@@ -55,6 +54,11 @@ endif
 ifeq ($(ARCH), win)
 	# TODO get rid of the mingw64 path
 	env PATH=dep/bin:/mingw64/bin ./$<
+endif
+
+sandbox-run: $(TARGET)
+ifeq ($(ARCH), mac)
+	sandbox-exec -f ./Rack.sb `which sh` -c 'DYLD_FALLBACK_LIBRARY_PATH=dep/lib ./$<'                                                                      2 ↵  ✹ ✭sandbox ‹2.4.2›
 endif
 
 debug: $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif
 
 sandbox-run: $(TARGET)
 ifeq ($(ARCH), mac)
-	sandbox-exec -f ./Rack.sb `which sh` -c 'DYLD_FALLBACK_LIBRARY_PATH=dep/lib ./$<'                                                                      2 ↵  ✹ ✭sandbox ‹2.4.2›
+	sandbox-exec -D RACK_HOME=$(PWD) -f ./Rack.sb `which sh` -c 'DYLD_FALLBACK_LIBRARY_PATH=dep/lib ./$<'                                                                      2 ↵  ✹ ✭sandbox ‹2.4.2›
 endif
 
 debug: $(TARGET)

--- a/Rack.sb
+++ b/Rack.sb
@@ -1,26 +1,15 @@
-
 (version 1)
-(debug allow)
+(import "system.sb")
 
-(define rack-home "RACK_HOME")
-
-; This is needed for IPC on OSX >= 10.6
 (allow ipc-posix-shm)
 
-; Allow inbound and outbound connections
 (allow network-outbound)
 (allow network-inbound)
 
-; Allow reading with sysctl
 (allow sysctl-read)
 
-; Allow it to read metadata
 (allow file-read-metadata)
 
-; Allow it to run processes and fork
-(allow process*)
-
-; Allow it to signal self
 (allow signal)
 
 (allow iokit-open)
@@ -29,34 +18,8 @@
 
 (allow system-socket)
 
-(allow file-read* file-write* (subpath (param rack-home)))
-
-; Allow file reading
-(allow file-read*
-    (regex
-        #"^/Applications/Rack.app"
-        #"^/Library/*"
-        #"^/System/Library/*"
-        #"^/usr/*"
-        #"^/dev/*"
-        #"/Users/jon/Projects/Rack"
-        #"/Users/[^.]+/Library/Saved Application State/com.vcvrack.rack.savedState"
-    )
-)
-
-; Allow write access to a subset of the above
-(allow file-write*
-    (regex
-        #"^/private/var/*"
-        #"^/private/tmp/*"
-        #"^/var/folders/th/*"
-    )
-)
-
-(allow file-issue-extension
-    (regex
-        #"^/private/var/*"
-    )
-)
+(allow file-read* (subpath (param "rackLocal")))
+(allow file-write* (subpath (param "rackLocal")))
+(allow file-read* (subpath (param "rackGlobal")))
 
 (deny default)

--- a/Rack.sb
+++ b/Rack.sb
@@ -2,6 +2,8 @@
 (version 1)
 (debug allow)
 
+(define rack-home "RACK_HOME")
+
 ; This is needed for IPC on OSX >= 10.6
 (allow ipc-posix-shm)
 
@@ -26,6 +28,8 @@
 (allow mach-lookup)
 
 (allow system-socket)
+
+(allow file-read* file-write* (subpath (param rack-home)))
 
 ; Allow file reading
 (allow file-read*

--- a/Rack.sb
+++ b/Rack.sb
@@ -1,0 +1,58 @@
+
+(version 1)
+(debug allow)
+
+; This is needed for IPC on OSX >= 10.6
+(allow ipc-posix-shm)
+
+; Allow inbound and outbound connections
+(allow network-outbound)
+(allow network-inbound)
+
+; Allow reading with sysctl
+(allow sysctl-read)
+
+; Allow it to read metadata
+(allow file-read-metadata)
+
+; Allow it to run processes and fork
+(allow process*)
+
+; Allow it to signal self
+(allow signal)
+
+(allow iokit-open)
+
+(allow mach-lookup)
+
+(allow system-socket)
+
+; Allow file reading
+(allow file-read*
+    (regex
+        #"^/Applications/Rack.app"
+        #"^/Library/*"
+        #"^/System/Library/*"
+        #"^/usr/*"
+        #"^/dev/*"
+        #"/Users/jon/Projects/Rack"
+        #"/Users/[^.]+/Library/Saved Application State/com.vcvrack.rack.savedState"
+    )
+)
+
+; Allow write access to a subset of the above
+(allow file-write*
+    (regex
+        #"^/private/var/*"
+        #"^/private/tmp/*"
+        #"^/var/folders/th/*"
+    )
+)
+
+(allow file-issue-extension
+    (regex
+        #"^/private/var/*"
+    )
+)
+
+(deny default)

--- a/include/sandbox.hpp
+++ b/include/sandbox.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace rack {
+bool sandboxInit();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "engine.hpp"
 #include "gui.hpp"
 #include "app.hpp"
+#include "sandbox.hpp"
 #include "plugin.hpp"
 #include "settings.hpp"
 #include "asset.hpp"
@@ -31,6 +32,7 @@ int main(int argc, char* argv[]) {
 		info("Local directory: %s", localDir.c_str());
 	}
 
+	sandboxInit();
 	pluginInit();
 	engineInit();
 	guiInit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,10 @@ int main(int argc, char* argv[]) {
 		info("Local directory: %s", localDir.c_str());
 	}
 
-	sandboxInit();
+	if(!sandboxInit()) {
+		info("Refusing to run without sandbox");
+		exit(1);
+	}
 	pluginInit();
 	engineInit();
 	guiInit();

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -73,12 +73,6 @@ bool sandboxInit() {
     info("Sandbox initialized!");
   }
   sandbox_free_error(error_buff);
-
-  FILE *file2 = fopen("/Users/jon/Documents/mg.txt", "rb");
-  if(!file2) {
-    info("Couldn't read private file");
-  }
-
   return success;
 }
 

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -1,0 +1,28 @@
+#include "sandbox.hpp"
+#include "util.hpp"
+namespace rack {
+#if defined(ARCH_MAC)
+#include <sandbox.h>
+
+bool sandboxInit() {
+  char* error_buff = NULL;
+  //int error = sandbox_init(final_sandbox_profile_str.c_str(), 0, &error_buff);
+  int error = sandbox_init(kSBXProfileNoInternet, SANDBOX_NAMED, &error_buff);
+  bool success = (error == 0 && error_buff == NULL);
+  if(!success) {
+    info("Sandbox initialization error (%d): %s", error, error_buff);
+  } else {
+    info("Sandbox initialized!");
+  }
+  sandbox_free_error(error_buff);
+
+  return success;
+}
+
+
+#else
+	bool sandboxInit() {
+    return false;
+  }
+#endif
+}

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -1,13 +1,71 @@
 #include "sandbox.hpp"
 #include "util.hpp"
+#include "asset.hpp"
+#include <vector>
+
 namespace rack {
 #if defined(ARCH_MAC)
 #include <sandbox.h>
+#include <stdlib.h>
+#include <sys/syslimits.h>
+extern "C" {
+
+int sandbox_init_with_parameters(const char *profile, uint64_t flags, const char *const parameters[], char **errorbuf);
+// Possible values for 'flags':
+#define SANDBOX_STRING  0x0000
+#define SANDBOX_NAMED   0x0001
+#define SANDBOX_BUILTIN 0x0002
+#define SANDBOX_FILE    0x0003
+
+}
+
+struct SandboxParams {
+  void* buf;
+  size_t count;
+  size_t size;
+};
 
 bool sandboxInit() {
-  char* error_buff = NULL;
-  //int error = sandbox_init(final_sandbox_profile_str.c_str(), 0, &error_buff);
-  int error = sandbox_init(kSBXProfileNoInternet, SANDBOX_NAMED, &error_buff);
+
+  /*
+  char* params = sandbox_create_params();
+  if (!params)
+    return false;
+
+  sandbox_set_param(params, "rackGlobal", assetGlobal("").c_str());
+  sandbox_set_param(params, "rackLocal", assetLocal("").c_str());
+  */
+  std::string profilePath = assetGlobal("Rack.sb").c_str();
+  FILE *file = fopen(profilePath.c_str(), "rb");
+  if(!file) {
+    info("Couldn't read sandbox profile");
+    return false;
+  }
+  fseek(file, 0, SEEK_END);
+  long fsize = ftell(file);
+  fseek(file, 0, SEEK_SET);  //same as rewind(f);
+
+  char *profileStr = (char*)malloc(fsize + 1);
+  fread(profileStr, fsize, 1, file);
+  fclose(file);
+  profileStr[fsize] = 0;
+
+  std::vector<const char *> params;
+  char resolved_path[PATH_MAX];
+
+  params.push_back("rackGlobal");
+  realpath(assetGlobal("").c_str(), resolved_path);
+  params.push_back(resolved_path);
+
+  params.push_back("rackLocal");
+  realpath(assetLocal("").c_str(), resolved_path);
+  params.push_back(resolved_path);
+
+  // The parameters array is null terminated.
+  params.push_back(nullptr);
+
+  char* error_buff = nullptr;
+  int error = sandbox_init_with_parameters(profileStr, SANDBOX_STRING, params.data(), &error_buff);
   bool success = (error == 0 && error_buff == NULL);
   if(!success) {
     info("Sandbox initialization error (%d): %s", error, error_buff);
@@ -15,6 +73,11 @@ bool sandboxInit() {
     info("Sandbox initialized!");
   }
   sandbox_free_error(error_buff);
+
+  FILE *file2 = fopen("/Users/jon/Documents/mg.txt", "rb");
+  if(!file2) {
+    info("Couldn't read private file");
+  }
 
   return success;
 }


### PR DESCRIPTION
(some) Rack users end up running a lot of poorly audited 3rd party code inside their application. It would be good to restrict the capabilities of the Rack application such that arbitrary files cannot be read or written.

I've cooked up the most basic possible Mac sandbox profile that actually works. Some of the paths are hard coded for my dev setup, but it's a starting point for verifying operation of Rack inside an application sandbox.


# Mac todo
- include [private version of sandbox.h](https://github.com/rpetrich/LightMessaging/blob/master/sandbox.h)
- File dialog

# Linux
- is NSJail / user namespaces acceptable?
- prototype with NSJail inside Rack.sh
- design exclusion list

# General
- File dialogs?