### PR TITLE
Allow custom Knob sensitivity

### DIFF
--- a/include/app.hpp
+++ b/include/app.hpp
@@ -23,7 +23,6 @@ struct SVGPanel;
 // A 1U module should be 15x380. Thus the width of a module should be a factor of 15.
 #define RACK_GRID_WIDTH 15
 #define RACK_GRID_HEIGHT 380
-#define KNOB_SENSITIVITY 0.0015
 
 static const Vec RACK_GRID_SIZE = Vec(15, 380);
 
@@ -201,7 +200,7 @@ struct Knob : ParamWidget {
 	/** Snap to nearest integer while dragging */
 	bool snap = false;
 	float dragValue;
-	float sensitivity = KNOB_SENSITIVITY;
+	float sensitivity = 0.0;
 	void onDragStart(EventDragStart &e) override;
 	void onDragMove(EventDragMove &e) override;
 	void onDragEnd(EventDragEnd &e) override;

--- a/include/app.hpp
+++ b/include/app.hpp
@@ -23,6 +23,7 @@ struct SVGPanel;
 // A 1U module should be 15x380. Thus the width of a module should be a factor of 15.
 #define RACK_GRID_WIDTH 15
 #define RACK_GRID_HEIGHT 380
+#define KNOB_SENSITIVITY 0.0015
 
 static const Vec RACK_GRID_SIZE = Vec(15, 380);
 
@@ -200,6 +201,7 @@ struct Knob : ParamWidget {
 	/** Snap to nearest integer while dragging */
 	bool snap = false;
 	float dragValue;
+	float sensitivity = KNOB_SENSITIVITY;
 	void onDragStart(EventDragStart &e) override;
 	void onDragMove(EventDragMove &e) override;
 	void onDragEnd(EventDragEnd &e) override;

--- a/src/app/Knob.cpp
+++ b/src/app/Knob.cpp
@@ -4,9 +4,9 @@
 // For GLFW_KEY_LEFT_CONTROL, etc.
 #include <GLFW/glfw3.h>
 
-
 namespace rack {
 
+#define KNOB_SENSITIVITY 0.0015
 
 
 void Knob::onDragStart(EventDragStart &e) {
@@ -16,8 +16,12 @@ void Knob::onDragStart(EventDragStart &e) {
 }
 
 void Knob::onDragMove(EventDragMove &e) {
+	float sens = sensitivity;
+	if (sens == 0.f) {
+		sens = KNOB_SENSITIVITY;
+	}
 	// Drag slower if Mod
-	float delta = sensitivity * (maxValue - minValue) * -e.mouseRel.y;
+	float delta = sens * (maxValue - minValue) * -e.mouseRel.y;
 	if (guiIsModPressed())
 		delta /= 16.0;
 	dragValue += delta;

--- a/src/app/Knob.cpp
+++ b/src/app/Knob.cpp
@@ -7,7 +7,6 @@
 
 namespace rack {
 
-#define KNOB_SENSITIVITY 0.0015
 
 
 void Knob::onDragStart(EventDragStart &e) {
@@ -18,7 +17,7 @@ void Knob::onDragStart(EventDragStart &e) {
 
 void Knob::onDragMove(EventDragMove &e) {
 	// Drag slower if Mod
-	float delta = KNOB_SENSITIVITY * (maxValue - minValue) * -e.mouseRel.y;
+	float delta = sensitivity * (maxValue - minValue) * -e.mouseRel.y;
 	if (guiIsModPressed())
 		delta /= 16.0;
 	dragValue += delta;


### PR DESCRIPTION
Use case is ten-turn-pots (they work wow!) for an FM radio tuner.
```C++
SVGKnob *knob = dynamic_cast<SVGKnob*>(createParam<RoundHugeBlackKnob>(Vec(0, 0), module, SDR::TUNE_PARAM, HZ_FLOOR, HZ_CEIL, HZ_CENTER));
knob->maxAngle += 10*M_PI;
knob->sensitivity /= 10.f;
addParam(knob);
```