### PR TITLE
Fixed Makefile for community v2 branch build instructions

### DIFF
--- a/plugin.mk
+++ b/plugin.mk
@@ -1,14 +1,16 @@
 # All paths here assume the PWD is plugin/something
+RACK_DIR ?= ../..
+
 
 FLAGS += -fPIC \
-	-I../../include -I../../dep/include
+	-I$(RACK_DIR)/include -I $(RACK_DIR)/dep/include
 
 ifdef SLUG
 	FLAGS += -DSLUG=$(SLUG)
 endif
 
 
-include ../../arch.mk
+include $(RACK_DIR)/arch.mk
 
 ifeq ($(ARCH), lin)
 	LDFLAGS += -shared
@@ -21,7 +23,7 @@ ifeq ($(ARCH), mac)
 endif
 
 ifeq ($(ARCH), win)
-	LDFLAGS += -shared -L../../ -lRack
+	LDFLAGS += -shared -L$(RACK_DIR) -lRack
 	TARGET = plugin.dll
 endif
 
@@ -30,7 +32,7 @@ DISTRIBUTABLES += $(TARGET)
 
 all: $(TARGET)
 
-include ../../compile.mk
+include $(RACK_DIR)/compile.mk
 
 clean:
 	rm -rfv build $(TARGET) dist


### PR DESCRIPTION
use RACK_DIR instead of `../..` for paths in Makefiles

- Compilation doesn't work but I think that's because I'm on the wrong branch for the submodules and include/util.hpp got renamed?