### PR TITLE
Add windowIsKeyPressed() function

### DIFF
--- a/include/window.hpp
+++ b/include/window.hpp
@@ -38,6 +38,7 @@ void windowCursorLock();
 void windowCursorUnlock();
 bool windowIsModPressed();
 bool windowIsShiftPressed();
+bool windowIsKeyPressed(int key);
 Vec windowGetWindowSize();
 void windowSetWindowSize(Vec size);
 Vec windowGetWindowPos();

--- a/src/app/Knob.cpp
+++ b/src/app/Knob.cpp
@@ -1,8 +1,6 @@
 #include "app.hpp"
 #include "window.hpp"
 #include "engine.hpp"
-// For GLFW_KEY_LEFT_CONTROL, etc.
-#include <GLFW/glfw3.h>
 
 
 namespace rack {

--- a/src/app/ModuleWidget.cpp
+++ b/src/app/ModuleWidget.cpp
@@ -219,7 +219,7 @@ void ModuleWidget::onMouseMove(EventMouseMove &e) {
 	// Don't delete the ModuleWidget if a TextField is focused
 	if (!gFocusedWidget) {
 		// Instead of checking key-down events, delete the module even if key-repeat hasn't fired yet and the cursor is hovering over the widget.
-		if (glfwGetKey(gWindow, GLFW_KEY_DELETE) == GLFW_PRESS || glfwGetKey(gWindow, GLFW_KEY_BACKSPACE) == GLFW_PRESS) {
+		if (windowIsKeyPressed(GLFW_KEY_DELETE) || windowIsKeyPressed(GLFW_KEY_BACKSPACE)) {
 			if (!windowIsModPressed() && !windowIsShiftPressed()) {
 				gRackWidget->deleteModule(this);
 				this->finalizeEvents();

--- a/src/ui/ScrollWidget.cpp
+++ b/src/ui/ScrollWidget.cpp
@@ -68,16 +68,16 @@ void ScrollWidget::onMouseMove(EventMouseMove &e) {
 		else if (windowIsModPressed())
 			arrowSpeed /= 4.0;
 
-		if (glfwGetKey(gWindow, GLFW_KEY_LEFT) == GLFW_PRESS) {
+		if (windowIsKeyPressed(GLFW_KEY_LEFT)) {
 			offset.x -= arrowSpeed;
 		}
-		if (glfwGetKey(gWindow, GLFW_KEY_RIGHT) == GLFW_PRESS) {
+		if (windowIsKeyPressed(GLFW_KEY_RIGHT)) {
 			offset.x += arrowSpeed;
 		}
-		if (glfwGetKey(gWindow, GLFW_KEY_UP) == GLFW_PRESS) {
+		if (windowIsKeyPressed(GLFW_KEY_UP)) {
 			offset.y -= arrowSpeed;
 		}
-		if (glfwGetKey(gWindow, GLFW_KEY_DOWN) == GLFW_PRESS) {
+		if (windowIsKeyPressed(GLFW_KEY_DOWN)) {
 			offset.y += arrowSpeed;
 		}
 	}

--- a/src/ui/TextField.cpp
+++ b/src/ui/TextField.cpp
@@ -1,8 +1,6 @@
 #include "ui.hpp"
 // for gVg
 #include "window.hpp"
-// for key codes
-#include <GLFW/glfw3.h>
 
 
 namespace rack {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -516,6 +516,10 @@ bool windowIsShiftPressed() {
 	return glfwGetKey(gWindow, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS || glfwGetKey(gWindow, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
 }
 
+bool windowIsKeyPressed(int key) {
+	return glfwGetKey(gWindow, key) == GLFW_PRESS;
+}
+
 Vec windowGetWindowSize() {
 	int width, height;
 	glfwGetWindowSize(gWindow, &width, &height);


### PR DESCRIPTION
Minor cleanup: Since there are already windowIsModPressed() and windowIsShiftPressed() I think it makes sense to have a windowIsKeyPressed(int key) function and not call glfwGetKey from anywhere in the project. This does not break the plugin API.