### PR TITLE
Pack inputs/outputs two "Light" into one "DualLight"

### DIFF
--- a/include/engine.hpp
+++ b/include/engine.hpp
@@ -21,12 +21,41 @@ struct Light {
 	void setBrightnessSmooth(float brightness);
 };
 
+struct DualLight {
+	/** The square of the brightness value */
+	float value = 0.0;
+
+	float getPositiveBrightness() {
+		return sqrtf(fmaxf(0.f, value));
+	}
+	float getNegativeBrightness() {
+		return sqrtf(fmaxf(0.f, -value));
+	}
+	void setSignedBrightness(float brightness) {
+		value = ((brightness < 0.f) ? -1.f : 1.f) * (brightness * brightness);
+	}
+	void setSignedBrightnessSmooth(float brightness, float dt) {
+		float v = brightness * brightness;
+		float abs_value = fabsf(value);
+		if (v < abs_value) {
+			// Fade out light with lambda = framerate
+			abs_value += (v - abs_value) * dt;
+
+		}
+		else {
+			// Immediately illuminate light
+			abs_value = v;
+		}
+		value = ((brightness < 0.f) ? -1.f : 1.f) * abs_value;
+	}
+};
+
 struct Input {
 	/** Voltage of the port, zero if not plugged in. Read-only by Module */
 	float value = 0.0;
 	/** Whether a wire is plugged in */
 	bool active = false;
-	Light plugLights[2];
+	DualLight plugLight;
 	/** Returns the value if a wire is plugged in, otherwise returns the given default value */
 	float normalize(float normalValue) {
 		return active ? value : normalValue;
@@ -38,7 +67,7 @@ struct Output {
 	float value = 0.0;
 	/** Whether a wire is plugged in */
 	bool active = false;
-	Light plugLights[2];
+	DualLight plugLight;
 };
 
 

--- a/src/app/Port.cpp
+++ b/src/app/Port.cpp
@@ -30,12 +30,12 @@ Port::~Port() {
 void Port::step() {
 	std::vector<float> values(2);
 	if (type == INPUT) {
-		values[0] = module->inputs[portId].plugLights[0].getBrightness();
-		values[1] = module->inputs[portId].plugLights[1].getBrightness();
+		values[0] = module->inputs[portId].plugLight.getPositiveBrightness();
+		values[1] = module->inputs[portId].plugLight.getNegativeBrightness();
 	}
 	else {
-		values[0] = module->outputs[portId].plugLights[0].getBrightness();
-		values[1] = module->outputs[portId].plugLights[1].getBrightness();
+		values[0] = module->outputs[portId].plugLight.getPositiveBrightness();
+		values[1] = module->outputs[portId].plugLight.getNegativeBrightness();
 	}
 	plugLight->setValues(values);
 }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -68,12 +68,15 @@ void engineDestroy() {
 }
 
 static void engineStep() {
-	// Param interpolation
+    
+    const float lambda = 60.f; // decay rate is 1 graphics frame
+    float dt = lambda * sampleTime;
+    
+    // Param interpolation
 	if (smoothModule) {
 		float value = smoothModule->params[smoothParamId].value;
-		const float lambda = 60.0; // decay rate is 1 graphics frame
 		float delta = smoothValue - value;
-		float newValue = value + delta * lambda * sampleTime;
+		float newValue = value + delta * dt;
 		if (value == newValue) {
 			// Snap to actual smooth value if the value doesn't change enough (due to the granularity of floats)
 			smoothModule->params[smoothParamId].value = smoothValue;
@@ -92,16 +95,12 @@ static void engineStep() {
 		// Step ports
 		for (Input &input : module->inputs) {
 			if (input.active) {
-				float value = input.value / 10.0;
-				input.plugLights[0].setBrightnessSmooth(value);
-				input.plugLights[1].setBrightnessSmooth(-value);
+				input.plugLight.setSignedBrightnessSmooth(input.value / 10.f, dt);
 			}
 		}
 		for (Output &output : module->outputs) {
 			if (output.active) {
-				float value = output.value / 10.0;
-				output.plugLights[0].setBrightnessSmooth(value);
-				output.plugLights[1].setBrightnessSmooth(-value);
+				output.plugLight.setSignedBrightnessSmooth(output.value / 10.f, dt);
 			}
 		}
 	}


### PR DESCRIPTION
...with a signed brightness. This remove one float per in/outputs and also divide by two the number of call to setBrightnessSmooth (that took up to 15% of the CPU time on my machine)

Extra: use float constants (10.f) instead of double (10.0). Avoid unnecessary conversions