### PR TITLE
QuadMIDIToCV with all poly modes

### DIFF
--- a/src/Core/QuadMIDIToCVInterface.cpp
+++ b/src/Core/QuadMIDIToCVInterface.cpp
@@ -258,8 +258,9 @@ struct QuadMIDIToCVInterface : Module {
 
 		for (int i = 0; i < 4; i++) {
 			uint8_t lastNote = notes[i];
+           		uint8_t lastGate = ((gates[i] || pedalgates[i]) && (!(reTrigger[i].process(engineGetSampleTime()))));
 			outputs[CV_OUTPUT + i].value = (lastNote - 60) / 12.f;
-			outputs[GATE_OUTPUT + i].value = gates[i] ? 10.f : 0.f;
+			outputs[GATE_OUTPUT + i].value = lastGate ? 10.f : 0.f;
 			outputs[VELOCITY_OUTPUT + i].value = rescale(noteData[lastNote].velocity, 0, 127, 0.f, 10.f);
 			outputs[AFTERTOUCH_OUTPUT + i].value = rescale(noteData[lastNote].aftertouch, 0, 127, 0.f, 10.f);
 		}


### PR DESCRIPTION
Overview of functionality:
ROTATE > Incoming note always takes the next available ch.
REUSE > If incoming note is repeated (already assigned to one ch) takes that ch, if not, it takes the next available ch.
RESET > Incoming note always takes the lowest available ch.
REASSIGN > Similar to RESET but when releasing notes they are reassigned continuously from ch 0 (keeping the order)
UNISON > Incoming note takes all 4 ch.
 
When receiving more than 4 notes "stealing" occurs, always taking the next ch. 
When keys are released, still pressed notes that where stolen are recovered. 
In modes other than REUSE (or UNISON), repeating a note with sustain pedal rotates  it over the channels producing "unison".
When using sustain pedal and playing and releasing many notes, still pressed notes are stolen, but they are recovered when sustain pedal is off.
I tested every possible combination of note(s) on off / sustain on off. 
also added a pulseGen for re-triggering notes when necessary

(I also added the MIDI channel if on MidiMessage)