### PR TITLE
Update default name of Jack RtAudio client to "VCV Rack"

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -244,7 +244,7 @@ void AudioIO::openStream() {
 
 		RtAudio::StreamOptions options;
 		options.flags |= RTAUDIO_JACK_DONT_CONNECT;
-		options.streamName = "VCVRack";
+		options.streamName = "VCV Rack";
 
 		int closestSampleRate = deviceInfo.preferredSampleRate;
 		for (int sr : deviceInfo.sampleRates) {

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -244,6 +244,7 @@ void AudioIO::openStream() {
 
 		RtAudio::StreamOptions options;
 		options.flags |= RTAUDIO_JACK_DONT_CONNECT;
+		options.streamName = "VCVRack";
 
 		int closestSampleRate = deviceInfo.preferredSampleRate;
 		for (int sr : deviceInfo.sampleRates) {


### PR DESCRIPTION
Hello,
This updates the default RtAudio Jack client name to VCV Rack. That is all, just a QOL request.
Cheers,
Arnaud