### PR TITLE
Multiple Rack instances

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "dep/rtaudio"]
 	path = dep/rtaudio
 	url = https://github.com/thestk/rtaudio.git
+[submodule "dep/argagg"]
+	path = dep/argagg
+	url = https://github.com/vietjtnguyen/argagg.git

--- a/dep/Makefile
+++ b/dep/Makefile
@@ -50,8 +50,9 @@ nanosvg = include/nanosvg.h
 oui-blendish = include/blendish.h
 osdialog = include/osdialog.h
 pffft = include/pffft.h
+argagg = include/argagg.hpp
 
-DEPS += $(glew) $(glfw) $(jansson) $(libspeexdsp) $(libcurl) $(libzip) $(rtmidi) $(rtaudio) $(nanovg) $(nanosvg) $(oui-blendish) $(osdialog) $(pffft)
+DEPS += $(glew) $(glfw) $(jansson) $(libspeexdsp) $(libcurl) $(libzip) $(rtmidi) $(rtaudio) $(nanovg) $(nanosvg) $(oui-blendish) $(osdialog) $(pffft) $(argagg)
 include $(RACK_DIR)/dep.mk
 
 
@@ -163,6 +164,9 @@ $(pffft):
 	$(WGET) "https://bitbucket.org/jpommier/pffft/get/29e4f76ac53b.zip"
 	$(UNZIP) 29e4f76ac53b.zip
 	cp jpommier-pffft-29e4f76ac53b/*.h include/
+	
+$(argagg): $(wildcard argagg/include/argagg/*.hpp)
+	cp argagg/include/argagg/*.hpp include/
 
 clean:
 	git clean -fdx

--- a/include/asset.hpp
+++ b/include/asset.hpp
@@ -7,7 +7,7 @@
 namespace rack {
 
 
-void assetInit(bool devMode);
+void assetInit(bool devMode, std::string customGlobalDir = std::string(), std::string customLocalDir = std::string());
 /** Returns the path of a global resource. Should only read files from this location. */
 std::string assetGlobal(std::string filename);
 /** Returns the path of a local resource. Can read and write files to this location. */

--- a/include/bridge.hpp
+++ b/include/bridge.hpp
@@ -22,7 +22,7 @@ struct BridgeMidiDriver : MidiDriver {
 };
 
 
-void bridgeInit();
+void bridgeInit(int customPort = BRIDGE_PORT);
 void bridgeDestroy();
 void bridgeAudioSubscribe(int channel, AudioIO *audio);
 void bridgeAudioUnsubscribe(int channel, AudioIO *audio);

--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -37,61 +37,61 @@ void assetInit(bool devMode, std::string customGlobalDir, std::string customLoca
 	if (customGlobalDir.empty()) {
 
 #if ARCH_MAC
-	  CFBundleRef bundle = CFBundleGetMainBundle();
-	  assert(bundle);
-	  CFURLRef resourcesUrl = CFBundleCopyResourcesDirectoryURL(bundle);
-	  char resourcesBuf[PATH_MAX];
-	  Boolean success = CFURLGetFileSystemRepresentation(resourcesUrl, TRUE, (UInt8*) resourcesBuf, sizeof(resourcesBuf));
-	  assert(success);
-	  CFRelease(resourcesUrl);
-	  globalDir = resourcesBuf;
+		CFBundleRef bundle = CFBundleGetMainBundle();
+		assert(bundle);
+		CFURLRef resourcesUrl = CFBundleCopyResourcesDirectoryURL(bundle);
+		char resourcesBuf[PATH_MAX];
+		Boolean success = CFURLGetFileSystemRepresentation(resourcesUrl, TRUE, (UInt8*) resourcesBuf, sizeof(resourcesBuf));
+		assert(success);
+		CFRelease(resourcesUrl);
+		globalDir = resourcesBuf;
 #endif
 #if ARCH_WIN
-	  char moduleBuf[MAX_PATH];
-	  DWORD length = GetModuleFileName(NULL, moduleBuf, sizeof(moduleBuf));
-	  assert(length > 0);
-	  PathRemoveFileSpec(moduleBuf);
-	  globalDir = moduleBuf;
+		char moduleBuf[MAX_PATH];
+		DWORD length = GetModuleFileName(NULL, moduleBuf, sizeof(moduleBuf));
+		assert(length > 0);
+		PathRemoveFileSpec(moduleBuf);
+		globalDir = moduleBuf;
 #endif
 #if ARCH_LIN
-	  // TODO For now, users should launch Rack from their terminal in the global directory
-	  globalDir = ".";
+		// TODO For now, users should launch Rack from their terminal in the global directory
+		globalDir = ".";
 #endif
 	}
 	else {
-	  globalDir = customGlobalDir;
+		globalDir = customGlobalDir;
 	}
 
 	if (customLocalDir.empty()) {
 #if ARCH_MAC
-	  // Get home directory
-	  struct passwd *pw = getpwuid(getuid());
-	  assert(pw);
-	  localDir = pw->pw_dir;
-	  localDir += "/Documents/Rack";
+		// Get home directory
+		struct passwd *pw = getpwuid(getuid());
+		assert(pw);
+		localDir = pw->pw_dir;
+		localDir += "/Documents/Rack";
 #endif
 #if ARCH_WIN
-	  // Get "My Documents" folder
-	  char documentsBuf[MAX_PATH];
-	  HRESULT result = SHGetFolderPath(NULL, CSIDL_MYDOCUMENTS, NULL, SHGFP_TYPE_CURRENT, documentsBuf);
-	  assert(result == S_OK);
-	  localDir = documentsBuf;
-	  localDir += "/Rack";
+		// Get "My Documents" folder
+		char documentsBuf[MAX_PATH];
+		HRESULT result = SHGetFolderPath(NULL, CSIDL_MYDOCUMENTS, NULL, SHGFP_TYPE_CURRENT, documentsBuf);
+		assert(result == S_OK);
+		localDir = documentsBuf;
+		localDir += "/Rack";
 #endif
 #if ARCH_LIN
-	  // Get home directory
-	  const char *homeBuf = getenv("HOME");
-	  if (!homeBuf) {
-	    struct passwd *pw = getpwuid(getuid());
-	    assert(pw);
-	    homeBuf = pw->pw_dir;
-	  }
-	  localDir = homeBuf;
-	  localDir += "/.Rack";
+		// Get home directory
+		const char *homeBuf = getenv("HOME");
+		if (!homeBuf) {
+			struct passwd *pw = getpwuid(getuid());
+			assert(pw);
+			homeBuf = pw->pw_dir;
+		}
+		localDir = homeBuf;
+		localDir += "/.Rack";
 #endif
 	}
 	else {
-	  localDir = customLocalDir;
+		localDir = customLocalDir;
 	}
 }
 

--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -28,10 +28,13 @@ static std::string localDir;
 
 void assetInit(bool devMode, std::string customGlobalDir, std::string customLocalDir) {
 	if (devMode) {
-		// Use current working directory if running in development mode
-		globalDir = ".";
-		localDir = ".";
-		return;
+		// Use current working directory by default if running in development mode
+		if (customGlobalDir.empty()) {
+			customGlobalDir = ".";
+		}
+		if (customLocalDir.empty()) {
+			customLocalDir = ".";
+		}
 	}
 
 	if (customGlobalDir.empty()) {

--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -19,6 +19,8 @@
 	#include <pwd.h>
 #endif
 
+#include <iostream>
+
 namespace rack {
 
 
@@ -62,7 +64,13 @@ void assetInit(bool devMode, std::string customGlobalDir, std::string customLoca
 #endif
 	}
 	else {
-		globalDir = customGlobalDir;
+		if (!systemIsDirectory(customGlobalDir)) {
+			std::cerr << "Selected global directory \"" <<  customGlobalDir << "\" does not exist or is not a directory, default to current directory." << std::endl;
+			globalDir = ".";
+		}
+		else {
+			globalDir = customGlobalDir;
+		}
 	}
 
 	if (customLocalDir.empty()) {
@@ -94,7 +102,13 @@ void assetInit(bool devMode, std::string customGlobalDir, std::string customLoca
 #endif
 	}
 	else {
-		localDir = customLocalDir;
+		if (!systemIsDirectory(customLocalDir)) {
+			std::cerr << "Selected local directory \"" <<  customLocalDir << "\" does not exist or is not a directory, default to current directory." << std::endl;
+			localDir = ".";
+		}
+		else {
+			localDir = customLocalDir;
+		}
 	}
 }
 

--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -19,7 +19,6 @@
 	#include <pwd.h>
 #endif
 
-
 namespace rack {
 
 
@@ -63,7 +62,7 @@ void assetInit(bool devMode, std::string customGlobalDir, std::string customLoca
 	  globalDir = customGlobalDir;
 	}
 
-	if (customGlobalDir.empty()) {
+	if (customLocalDir.empty()) {
 #if ARCH_MAC
 	  // Get home directory
 	  struct passwd *pw = getpwuid(getuid());

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -282,7 +282,7 @@ static void clientRun(int client) {
 }
 
 
-static void serverConnect() {
+static void serverConnect(int customPort) {
 	// Initialize sockets
 #if ARCH_WIN
 	WSADATA wsaData;
@@ -299,7 +299,8 @@ static void serverConnect() {
 	struct sockaddr_in addr;
 	memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
-	addr.sin_port = htons(BRIDGE_PORT);
+        warn("Bridge server port: %i", customPort);
+	addr.sin_port = htons(customPort);
 #if ARCH_WIN
 	addr.sin_addr.s_addr = inet_addr(BRIDGE_HOST);
 #else
@@ -365,10 +366,10 @@ static void serverConnect() {
 	}
 }
 
-static void serverRun() {
+static void serverRun(int customPort) {
 	while (serverRunning) {
 		std::this_thread::sleep_for(std::chrono::duration<double>(0.1));
-		serverConnect();
+		serverConnect(customPort);
 	}
 }
 
@@ -403,9 +404,9 @@ void BridgeMidiDriver::unsubscribeInputDevice(int deviceId, MidiInput *midiInput
 }
 
 
-void bridgeInit() {
+void bridgeInit(int customPort) {
 	serverRunning = true;
-	serverThread = std::thread(serverRun);
+	serverThread = std::thread(serverRun, customPort);
 
 	driver = new BridgeMidiDriver();
 	midiDriverAdd(BRIDGE_DRIVER, driver);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,11 +24,15 @@ using namespace rack;
 int main(int argc, char* argv[]) {
 	bool devMode = false;
 	std::string patchFile;
+	std::string customLocalDir;
+	std::string customGlobalDir;
 
 	// Parse command line arguments
 	argagg::parser argparser {{
 	    { "help", {"-h", "--help"}, "shows this help message", 0},
-	    { "devmod", {"-d", "--devmod"}, "enable dev mode", 0},
+	    { "devmod", {"-d", "--devmod"}, "enables dev mode (supersedes local/global folders)", 0},
+	    { "global", {"-g", "--globaldir"}, "set golbalDir", 1},
+	    { "local", {"-l", "--localdir"}, "set localDir", 1},
 	}};
 
 	argagg::parser_results args;
@@ -50,6 +54,14 @@ int main(int argc, char* argv[]) {
 	  devMode = true;
 	}
 
+	if (args["global"]) {
+	  customGlobalDir = args["global"].as<std::string>();
+	}
+
+	if (args["local"]) {
+	  customLocalDir = args["local"].as<std::string>();
+	}
+
 	// Filename as first positional argument
 	if (args.pos.size() > 0) {
 	  patchFile = args.as<std::string>(0);
@@ -57,7 +69,7 @@ int main(int argc, char* argv[]) {
 
 	// Initialize environment
 	randomInit();
-	assetInit(devMode);
+	assetInit(devMode, customGlobalDir, customLocalDir);
 	loggerInit(devMode);
 
 	// Log environment

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,47 +30,47 @@ int main(int argc, char* argv[]) {
 
 	// Parse command line arguments
 	argagg::parser argparser {{
-	    { "help", {"-h", "--help"}, "shows this help message", 0},
-	    { "devmod", {"-d", "--devmod"}, "enables dev mode (supersedes local/global folders)", 0},
-	    { "global", {"-g", "--globaldir"}, "set golbalDir", 1},
-	    { "local", {"-l", "--localdir"}, "set localDir", 1},
-	    { "port", {"-p", "--port"}, "Bridge port number", 1},
+		{ "help", {"-h", "--help"}, "shows this help message", 0},
+		{ "devmod", {"-d", "--devmod"}, "enables dev mode (supersedes local/global folders)", 0},
+		{ "global", {"-g", "--globaldir"}, "set golbalDir", 1},
+		{ "local", {"-l", "--localdir"}, "set localDir", 1},
+		{ "port", {"-p", "--port"}, "Bridge port number", 1},
 	}};
 
 	argagg::parser_results args;
 
 	try {
-	  args = argparser.parse(argc, argv);
+		args = argparser.parse(argc, argv);
 	} catch (const std::exception& e) {
-	  std::cerr << "Encountered exception while parsing arguments: " << e.what() << std::endl;
-	  return EXIT_FAILURE;
+		std::cerr << "Encountered exception while parsing arguments: " << e.what() << std::endl;
+		return EXIT_FAILURE;
 	}
 
 	if (args["help"]) {
-	  std::cerr << "Usage: program [options] [FILENAME]" << std::endl;
-	  std::cerr << argparser;
-	  return EXIT_SUCCESS;
+		std::cerr << "Usage: program [options] [FILENAME]" << std::endl;
+		std::cerr << argparser;
+		return EXIT_SUCCESS;
 	}
 
 	if (args["devmod"]) {
-	  devMode = true;
+		devMode = true;
 	}
 
 	if (args["global"]) {
-	  customGlobalDir = args["global"].as<std::string>();
+		customGlobalDir = args["global"].as<std::string>();
 	}
 
 	if (args["local"]) {
-	  customLocalDir = args["local"].as<std::string>();
+		customLocalDir = args["local"].as<std::string>();
 	}
 
 	if (args["port"]) {
-	  customBridgePort = args["port"].as<int>();
+		customBridgePort = args["port"].as<int>();
 	}
 
 	// Filename as first positional argument
 	if (args.pos.size() > 0) {
-	  patchFile = args.as<std::string>(0);
+		patchFile = args.as<std::string>(0);
 	}
 
 	// Initialize environment
@@ -90,10 +90,10 @@ int main(int argc, char* argv[]) {
 	engineInit();
 	rtmidiInit();
 	if (customBridgePort > 0) {
-	  bridgeInit(customBridgePort);
+		bridgeInit(customBridgePort);
 	}
 	else {
-	  bridgeInit();
+		bridgeInit();
 	}
 	keyboardInit();
 	gamepadInit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@ int main(int argc, char* argv[]) {
 	std::string patchFile;
 	std::string customLocalDir;
 	std::string customGlobalDir;
+	int customBridgePort = -1;
 
 	// Parse command line arguments
 	argagg::parser argparser {{
@@ -33,6 +34,7 @@ int main(int argc, char* argv[]) {
 	    { "devmod", {"-d", "--devmod"}, "enables dev mode (supersedes local/global folders)", 0},
 	    { "global", {"-g", "--globaldir"}, "set golbalDir", 1},
 	    { "local", {"-l", "--localdir"}, "set localDir", 1},
+	    { "port", {"-p", "--port"}, "Bridge port number", 1},
 	}};
 
 	argagg::parser_results args;
@@ -62,6 +64,10 @@ int main(int argc, char* argv[]) {
 	  customLocalDir = args["local"].as<std::string>();
 	}
 
+	if (args["port"]) {
+	  customBridgePort = args["port"].as<int>();
+	}
+
 	// Filename as first positional argument
 	if (args.pos.size() > 0) {
 	  patchFile = args.as<std::string>(0);
@@ -83,7 +89,12 @@ int main(int argc, char* argv[]) {
 	pluginInit(devMode);
 	engineInit();
 	rtmidiInit();
-	bridgeInit();
+	if (customBridgePort > 0) {
+	  bridgeInit(customBridgePort);
+	}
+	else {
+	  bridgeInit();
+	}
 	keyboardInit();
 	gamepadInit();
 	windowInit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
 	// Parse command line arguments
 	argagg::parser argparser {{
 		{ "help", {"-h", "--help"}, "shows this help message", 0},
-		{ "devmod", {"-d", "--devmod"}, "enables dev mode (supersedes local/global folders)", 0},
+		{ "devmod", {"-d", "--devmod"}, "enables dev mode (will default local/global folders to current folder)", 0},
 		{ "global", {"-g", "--globaldir"}, "set golbalDir", 1},
 		{ "local", {"-l", "--localdir"}, "set localDir", 1},
 		{ "port", {"-p", "--port"}, "Bridge port number", 1},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,8 @@
 #include "util/color.hpp"
 
 #include "osdialog.h"
+#include "argagg.hpp"
+
 #include <unistd.h>
 
 
@@ -24,18 +26,33 @@ int main(int argc, char* argv[]) {
 	std::string patchFile;
 
 	// Parse command line arguments
-	int c;
-	opterr = 0;
-	while ((c = getopt(argc, argv, "d")) != -1) {
-		switch (c) {
-			case 'd': {
-				devMode = true;
-			} break;
-			default: break;
-		}
+	argagg::parser argparser {{
+	    { "help", {"-h", "--help"}, "shows this help message", 0},
+	    { "devmod", {"-d", "--devmod"}, "enable dev mode", 0},
+	}};
+
+	argagg::parser_results args;
+
+	try {
+	  args = argparser.parse(argc, argv);
+	} catch (const std::exception& e) {
+	  std::cerr << "Encountered exception while parsing arguments: " << e.what() << std::endl;
+	  return EXIT_FAILURE;
 	}
-	if (optind < argc) {
-		patchFile = argv[optind];
+
+	if (args["help"]) {
+	  std::cerr << "Usage: program [options] [FILENAME]" << std::endl;
+	  std::cerr << argparser;
+	  return EXIT_SUCCESS;
+	}
+
+	if (args["devmod"]) {
+	  devMode = true;
+	}
+
+	// Filename as first positional argument
+	if (args.pos.size() > 0) {
+	  patchFile = args.as<std::string>(0);
 	}
 
 	// Initialize environment


### PR DESCRIPTION
Probably I could have started a discussion first, but I was too curious, and since it works... well, why not show the code? :)

I added several CLI options that could be used to launch multiple Rack instances. With the proposed modification, it is possible to explicitly set global / local folders, _and_ to set the TCP port used by Bridge. With dedicated local folders (e.g. separate autosaves) and Bridge servers, I don't see anything that would prevent multiple Rack instances to run smoothly. You commented elsewhere, e.g. #779  #973, that Rack is not designed for multiple instances, did I miss something?

If you want to limit such functionality because it could create an overhead when you provide support for Rack, maybe it could be documented as an experimental feature, e.g. "do that at your own risk"?

I canot think of any side effects (except if one tries to update plugins in parallel when multiple Rack pointing to the same global folder??), and the program behave as usual when the options are not used (i.e. same default values). 

IMHO the result looks great, I can create multiple "instruments" without having to merge by hand multiple patches  -- and "thanks" to the fact that there is no multi-threading at the moment, I suspect the overall performance is better ^^

Note that I also updated the Bridge VST plugin in order to select the TCP port of the server (now there might be a slight confusion between "TCP port" and "port", can be solved with proper names / doc).  Even though it seems trivial to update the AU as well, I don't have access to a Mac and I am not confortable developing blindly. See https://gItithub.com/jfrey-xx/Bridge/tree/params

Hence it is also possible to exchange signals between Rack instances, e.g. _via_ the Bridge plugin and a VST host. Depending on the application the delay induced by the network buffers might be noticeable, and ideally it should be possible to directly send messages from one Bridge server to the other (i.e. without a plugin host). At some point I wondered if I should try to customize as well the IP address, to enable remote communications on the network and echo #634, however from my understanding the VST interface seems poorly suited to do so. Indeed each parameter is a float, and this "float limitation" is why on the VST side the number of TCP ports is limited to 1000, starting with the default Bridge port.

Overall, I think that the changes are little intrusive while they could answer to requests coming from a niche (?) of users that would like to explore alternative usages.

I know you do not often accept PR, but if despite the shift in paradigme you think this one is interesting, let me know how I can improve the code/doc in order to comply with Rack's standards. For example, to ease CLI parsing I am using  [argagg ](https://github.com/vietjtnguyen/argagg) (MIT licence), but I did not know if I should directly drop the one header file in the repo, if I should fetch this dep as zip file or add it as a submodule (at the moment: git submodule).

