### PR TITLE
Unnecessary to filter MIDI channel (line 262)

### DIFF
--- a/src/Core/QuadMIDIToCVInterface.cpp
+++ b/src/Core/QuadMIDIToCVInterface.cpp
@@ -258,8 +258,8 @@ struct QuadMIDIToCVInterface : Module {
 
 	void processMessage(MidiMessage msg) {
 		// filter MIDI channel
-		if ((midiInput.channel > -1) && (midiInput.channel != msg.channel()))
-			return;
+//		if ((midiInput.channel > -1) && (midiInput.channel != msg.channel()))
+//			return;
 
 		switch (msg.status()) {
 			// note off


### PR DESCRIPTION
... MIDI Channel is already filtered in midi.cpp line 162 (...just realized this while working on my modules...)