### PR TITLE
Workaround for segfault crash when using xmonad

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <queue>
 #include <thread>
+#include <cstdlib>
 
 #include "osdialog.h"
 
@@ -559,6 +560,8 @@ void windowSetWindowPos(Vec pos) {
 }
 
 bool windowIsMaximized() {
+  if (getenv("RACK_XMONAD_HACK"))
+    return true;
 	return glfwGetWindowAttrib(gWindow, GLFW_MAXIMIZED);
 }
 


### PR DESCRIPTION
Since the real underlying bug here is (apparently) in GLFW, this approach -- simply treat the window as always maximized -- seems reasonable enough to put in the published binary to me.  Will save some people from having to compile at all.