### PR TITLE
Nudge tooltips to fit within the window

### DIFF
--- a/src/ui/Tooltip.cpp
+++ b/src/ui/Tooltip.cpp
@@ -1,5 +1,6 @@
 #include <ui/Tooltip.hpp>
 #include <app.hpp>
+#include <app/Scene.hpp>
 #include <window.hpp>
 
 
@@ -13,6 +14,8 @@ void Tooltip::step() {
 	box.size.y = bndLabelHeight(APP->window->vg, -1, text.c_str(), INFINITY);
 	// Position near cursor. This assumes that `this` is added to the root widget.
 	box.pos = APP->window->mousePos.plus(math::Vec(15, 15));
+	// Ensure that it fits within the window.
+	box = box.nudge(APP->scene->box);
 	Widget::step();
 }
 


### PR DESCRIPTION
Tooltips on the right side of the new v1 module browser can be cut off because they appear partly off screen:

<img width="752" alt="tooltip-cutoff" src="https://user-images.githubusercontent.com/44385/60021256-d278b200-96d0-11e9-942a-33e8241800da.png">

This uses the `nudge` method to keep it within the bounds of the window:

<img width="752" alt="tooltip-nudged" src="https://user-images.githubusercontent.com/44385/60021276-e0c6ce00-96d0-11e9-9d20-8051211706c3.png">
