### PR TITLE
Continuously build and upload AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: xenial
+
+install:
+  - sudo apt-get -y install cmake curl xorg-dev libglu1-mesa-dev freeglut3-dev gdb jq libasound-dev libasound2-dev libgl1-mesa-dev libglew-dev libglu1-mesa-dev libgtk2.0-dev libjack-jackd2-dev libjansson-dev libx11-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev libzip-dev mesa-common-dev zlib1g-dev libglfw3-dev
+
+script:
+  # Build Rack
+  - git submodule update --init --recursive
+  - sed -i -e 's|--with-jack|--without-jack|g' dep/Makefile
+  - make dep -j$(nproc)
+  - make -j$(nproc)
+  # make INSTALL_ROOT=appdir -j$(nproc) install ; find appdir/ # https://github.com/VCVRack/Rack/issues/1515
+  - mkdir -p appdir/usr/bin ; cp Rack appdir/usr/bin/rack ; strip appdir/usr/bin/rack # FIXME, see above
+  - mkdir -p appdir/usr/share/icons/512x512/apps ; cp res/icon.png appdir/usr/share/icons/512x512/apps/rack.png # FIXME, see above
+  - mkdir -p appdir/usr/share/applications/ ; cp res/rack.desktop appdir/usr/share/applications/ # FIXME, see above
+  - cp -r res/ appdir/usr/ # FIXME, see above; normally this should go to appdir/usr/share/rack/
+  - find appdir/
+  # Only then can we build the plugins
+  - cd plugins/
+  - git clone https://github.com/VCVRack/Fundamental
+  - cd Fundamental
+  - git submodule update --init --recursive
+  - make dep -j$(nproc)
+  - make -j$(nproc)
+  - make dist
+  - cd ../../
+  - find . -name 'Fundamental*.zip' -exec cp {} ./appdir/usr/ \;
+  - wget -c -nv "https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64" -O ./appdir/AppRun ; chmod +x ./appdir/AppRun # FIXME: Would not be needed if res was loaded from a path relative to the mani binary
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+
+after_success:
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh Rack*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/res/rack.desktop
+++ b/res/rack.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Rack
+Comment=Open-source virtual modular synthesizer 
+Exec=rack
+Icon=rack
+Type=Application
+Categories=AudioVideo;


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines
- Decentralized

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.