### PR TITLE
support sending of longer (sysex) midi msgs

### DIFF
--- a/include/dsp/midi.hpp
+++ b/include/dsp/midi.hpp
@@ -213,6 +213,8 @@ struct MidiGenerator {
 	}
 
 	virtual void onMessage(midi::Message message) {}
+
+	virtual void onMessage(uint8_t* bytes, size_t size) {}
 };
 
 

--- a/include/midi.hpp
+++ b/include/midi.hpp
@@ -106,6 +106,7 @@ struct OutputDevice : Device {
 	void subscribe(Output* input);
 	void unsubscribe(Output* input);
 	virtual void sendMessage(Message message) {}
+	virtual void sendMessage(uint8_t* bytes, size_t size) {}
 };
 
 ////////////////////
@@ -184,6 +185,7 @@ struct Output : Port {
 	std::vector<int> getChannels() override;
 
 	void sendMessage(Message message);
+	void sendMessage(uint8_t* bytes, size_t size);
 };
 
 

--- a/src/midi.cpp
+++ b/src/midi.cpp
@@ -264,6 +264,12 @@ void Output::sendMessage(Message message) {
 	}
 }
 
+void Output::sendMessage(uint8_t* bytes, size_t size) {
+	if (outputDevice) {
+		outputDevice->sendMessage(bytes, size);
+	}
+}
+
 
 ////////////////////
 // midi

--- a/src/rtmidi.cpp
+++ b/src/rtmidi.cpp
@@ -70,6 +70,10 @@ struct RtMidiOutputDevice : midi::OutputDevice {
 	void sendMessage(midi::Message message) override {
 		rtMidiOut->sendMessage(message.bytes, message.size);
 	}
+
+	void sendMessage(uint8_t* bytes, size_t size) override {
+		rtMidiOut->sendMessage(bytes, size);
+	}
 };
 
 


### PR DESCRIPTION
This simply adds some overloaded methods for sending raw midi bytes. The related ticket is https://github.com/VCVRack/Rack/issues/1703

which is marked as duplicate of https://github.com/VCVRack/Rack/issues/1433

This new functionality is used for my plugin SidEx and seems to be already needed by a potential user: https://github.com/wipu/sidex-vcv/issues/1

Since this patch only adds, it shouldn't break API compabitility and could be merged without problems. I have applied astyle formatting but I'm not aware of any other QA requirements (like unit tests). Feel free to polish the patch if it lacks something.