### PR TITLE
Allow to disable the workaround "unconsumed messages getting stuck in the future".

### DIFF
--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -61,6 +61,7 @@ extern float knobLinearSensitivity;
 extern float knobScrollSensitivity;
 extern float sampleRate;
 extern int threadCount;
+extern bool disableDawTimeWarpWorkaround;
 extern bool tooltips;
 extern bool cpuMeter;
 extern bool lockModules;

--- a/src/app/MenuBar.cpp
+++ b/src/app/MenuBar.cpp
@@ -548,6 +548,9 @@ struct EngineButton : MenuButton {
 				));
 			}
 		}));
+		menu->addChild(createCheckMenuItem("Disable DAW time warp workaround", "", 
+			[=]() { return settings::disableDawTimeWarpWorkaround; },
+			[=]() { settings::disableDawTimeWarpWorkaround ^= true; }));
 	}
 };
 

--- a/src/midi.cpp
+++ b/src/midi.cpp
@@ -7,6 +7,7 @@
 #include <string.hpp>
 #include <system.hpp>
 #include <context.hpp>
+#include <settings.hpp>
 #include <engine/Engine.hpp>
 
 
@@ -339,11 +340,13 @@ bool InputQueue::tryPop(Message* messageOut, int64_t maxFrame) {
 		return true;
 	}
 
-	// If next MIDI message is too far in the future, clear the queue.
-	// This solves the issue of unconsumed messages getting stuck in the future when a DAW rewinds the engine frame.
-	int futureFrames = 2 * APP->engine->getBlockFrames();
-	if (msg.getFrame() - maxFrame > futureFrames) {
-		internal->queue.clear();
+	if (!rack::settings::disableDawTimeWarpWorkaround) {
+		// If next MIDI message is too far in the future, clear the queue.
+		// This solves the issue of unconsumed messages getting stuck in the future when a DAW rewinds the engine frame.
+		int futureFrames = 2 * APP->engine->getBlockFrames();
+		if (msg.getFrame() - maxFrame > futureFrames) {
+			internal->queue.clear();
+		}
 	}
 	return false;
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -36,6 +36,7 @@ float knobLinearSensitivity = 0.001f;
 float knobScrollSensitivity = 0.001f;
 float sampleRate = 0;
 int threadCount = 1;
+bool disableDawTimeWarpWorkaround = false;
 bool tooltips = true;
 bool cpuMeter = false;
 bool lockModules = false;
@@ -136,6 +137,8 @@ json_t* toJson() {
 	json_object_set_new(rootJ, "sampleRate", json_real(sampleRate));
 
 	json_object_set_new(rootJ, "threadCount", json_integer(threadCount));
+
+	json_object_set_new(rootJ, "disableDawTimeWarpWorkaround", json_boolean(disableDawTimeWarpWorkaround));
 
 	json_object_set_new(rootJ, "tooltips", json_boolean(tooltips));
 
@@ -304,6 +307,10 @@ void fromJson(json_t* rootJ) {
 	json_t* threadCountJ = json_object_get(rootJ, "threadCount");
 	if (threadCountJ)
 		threadCount = json_integer_value(threadCountJ);
+
+	json_t* disableDawTimeWarpWorkaroundJ = json_object_get(rootJ, "disableDawTimeWarpWorkaround");
+	if (disableDawTimeWarpWorkaroundJ)
+		disableDawTimeWarpWorkaround = json_boolean_value(disableDawTimeWarpWorkaroundJ);
 
 	json_t* tooltipsJ = json_object_get(rootJ, "tooltips");
 	if (tooltipsJ)


### PR DESCRIPTION
This PR adds a settings (with menu entry and json persistency) to disable the workaround "DAW rewinding the engine frame".

The reason is because this workaround is causing MIDI events drops at low block size settings.
Talking about it here: https://community.vcvrack.com/t/midi-cv-module-missing-notes/16099

I don't think it is the way to go but it should trigger a discussion at least. This fix seems hacky in the first place, at least given my (very low) comprehension of it. For example I don't really understand how the delta could reach more than 2 times the block frame size since when the message is pushed in `void InputDevice::onMessage(const Message& message)` it seems caped to happen in next block.

Anyway I will be happy to fix this the best possible way.

Thanks !