### PR TITLE
Fix fill matching in helper.py

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -350,7 +350,7 @@ def panel_to_components(tree):
 		if not color:
 			style = el.get('style')
 			if style:
-				color_match = re.search(r'fill:\S*(#[0-9a-fA-F]{6})', style)
+				color_match = re.search(r'fill:\s*(#[0-9a-fA-F]{6})', style)
 				color = color_match.group(1)
 		if not color:
 			eprint(f"Cannot get color of component: {el}")


### PR DESCRIPTION
Previously, helper.py's colour-matching regex would match greedily any
non-whitespace (\S), which caused styles written out by Inkscape to fail
to be parsed correctly.

Instead, match for whitespace with \s.

As an example, in a REPL:
import re

style = "font-variation-settings:normal;opacity:1;fill:#ff00ff;fill-opacity:1;stop-color:#000000;stop-opacity:1"
color_match = re.search(r'fill:\s*(#[0-9a-fA-F]{6})',style)
print (color_match.group(1))

(Prints #ff00ff - correct)

vs.

import re

style = "font-variation-settings:normal;opacity:1;fill:#ff00ff;fill-opacity:1;stop-color:#000000;stop-opacity:1"
color_match = re.search(r'fill:\S*(#[0-9a-fA-F]{6})',style)
print (color_match.group(1))

(Prints #000000 - incorrect)