### PR TITLE
Fix memory alignment for buffers used by pffft

### DIFF
--- a/include/dsp/fir.hpp
+++ b/include/dsp/fir.hpp
@@ -42,16 +42,16 @@ struct RealTimeConvolver {
 	RealTimeConvolver(size_t blockSize) {
 		this->blockSize = blockSize;
 		pffft = pffft_new_setup(blockSize * 2, PFFFT_REAL);
-		outputTail = new float[blockSize];
+		outputTail = (float*) pffft_aligned_malloc(sizeof(float) * blockSize);
 		std::memset(outputTail, 0, blockSize * sizeof(float));
-		tmpBlock = new float[blockSize * 2];
+		tmpBlock = (float*) pffft_aligned_malloc(sizeof(float) * blockSize * 2);
 		std::memset(tmpBlock, 0, blockSize * 2 * sizeof(float));
 	}
 
 	~RealTimeConvolver() {
 		setKernel(NULL, 0);
-		delete[] outputTail;
-		delete[] tmpBlock;
+		pffft_aligned_free(outputTail);
+		pffft_aligned_free(tmpBlock);
 		pffft_destroy_setup(pffft);
 	}
 

--- a/src/dsp/minblep.cpp
+++ b/src/dsp/minblep.cpp
@@ -10,7 +10,7 @@ namespace dsp {
 void minBlepImpulse(int z, int o, float* output) {
 	// Symmetric sinc array with `z` zero-crossings on each side
 	int n = 2 * z * o;
-	float* x = new float[n];
+	float* x = (float*) pffft_aligned_malloc(sizeof(float) * n);
 	for (int i = 0; i < n; i++) {
 		float p = math::rescale((float) i, 0.f, (float)(n - 1), (float) - z, (float) z);
 		x[i] = sinc(p);
@@ -20,7 +20,7 @@ void minBlepImpulse(int z, int o, float* output) {
 	blackmanHarrisWindow(x, n);
 
 	// Real cepstrum
-	float* fx = new float[2 * n];
+	float* fx = (float*) pffft_aligned_malloc(sizeof(float) * 2 * n);
 	// Valgrind complains that the array is uninitialized for some reason, unless we clear it.
 	std::memset(fx, 0, sizeof(float) * 2 * n);
 	RealFFT rfft(n);
@@ -75,8 +75,8 @@ void minBlepImpulse(int z, int o, float* output) {
 	std::memcpy(output, x, n * sizeof(float));
 
 	// Cleanup
-	delete[] x;
-	delete[] fx;
+	pffft_aligned_free(x);
+	pffft_aligned_free(fx);
 }
 
 


### PR DESCRIPTION
This fixes memory alignment for buffers used by pffft, as required by at least `pffft_transform` and `irfft`.
If you check pffft code, you will see an assert for non-aligned memory use.

Typically not seen on 64bit OSes but happens quite frequently for 32bit ones.


Now I know Rack doesn't take pull requests, mainly because of the non-opensource codebase side (and effort, but this PR in specific is of no effort).
To make things easier, please take these changes and do with them as you please.
I am here in written text giving you full rights to this patch / code changes.
