### PR TITLE
Fix memory alignment for SIMD

### DIFF
--- a/include/engine/Port.hpp
+++ b/include/engine/Port.hpp
@@ -13,7 +13,9 @@ static const int PORT_MAX_CHANNELS = 16;
 
 struct Port {
 	/** Voltage of the port. */
-	union {
+	/** NOTE alignas is required in order to allow SSE usage.
+	Consecutive data (like in a vector) would otherwise pack Ports in a way that breaks SSE. */
+	union alignas(32) {
 		/** Unstable API. Use getVoltage() and setVoltage() instead. */
 		float voltages[PORT_MAX_CHANNELS] = {};
 		/** DEPRECATED. Unstable API. Use getVoltage() and setVoltage() instead. */

--- a/include/simd/Vector.hpp
+++ b/include/simd/Vector.hpp
@@ -34,7 +34,8 @@ struct Vector<float, 4> {
 	using type = float;
 	constexpr static int size = 4;
 
-	union {
+	/** NOTE alignas is required in order to allow SSE usage. */
+	union alignas(32) {
 		__m128 v;
 		/** Accessing this array of scalars is slow and defeats the purpose of vectorizing.
 		*/
@@ -108,7 +109,8 @@ struct Vector<int32_t, 4> {
 	using type = int32_t;
 	constexpr static int size = 4;
 
-	union {
+	/** NOTE alignas is required in order to allow SSE usage. */
+	union alignas(32) {
 		__m128i v;
 		int32_t s[4];
 	};


### PR DESCRIPTION
Similar to #1936 this fixes issues regarding memory alignment.
Here these issues can happen on any OS, I had the case where changing `Port` struct would lead to crashes due to how these were packed in a std::vector.
SSE (and NEON) requires the data it accesses to be aligned, otherwise results in a crash (SIGBUS on ARM).
I guess Rack was lucky that `Port` contents are able to be packed together in a way that keeps SSE working.

Same with #1936 please take these changes and do with them as you please.
I am here in written text giving you full rights to this patch / code changes.

