### PR TITLE
Feature request / proposal: use constexpr whenever possible

### DIFF
--- a/include/app/common.hpp
+++ b/include/app/common.hpp
@@ -15,8 +15,8 @@ namespace app {
 
 
 // A 1HPx3U module should be 15x380 pixels. Thus the width of a module should be a factor of 15.
-static const float RACK_GRID_WIDTH = 15;
-static const float RACK_GRID_HEIGHT = 380;
+static constexpr const float RACK_GRID_WIDTH = 15;
+static constexpr const float RACK_GRID_HEIGHT = 380;
 static const math::Vec RACK_GRID_SIZE = math::Vec(RACK_GRID_WIDTH, RACK_GRID_HEIGHT);
 static const math::Vec RACK_OFFSET = RACK_GRID_SIZE.mult(math::Vec(2000, 100));
 

--- a/include/dsp/common.hpp
+++ b/include/dsp/common.hpp
@@ -14,9 +14,9 @@ namespace dsp {
 
 // Constants
 
-static const float FREQ_C4 = 261.6256f;
-static const float FREQ_A4 = 440.0000f;
-static const float FREQ_SEMITONE = 1.0594630943592953f;
+static constexpr const float FREQ_C4 = 261.6256f;
+static constexpr const float FREQ_A4 = 440.0000f;
+static constexpr const float FREQ_SEMITONE = 1.0594630943592953f;
 
 // Mathematical functions
 

--- a/include/engine/Port.hpp
+++ b/include/engine/Port.hpp
@@ -8,7 +8,7 @@ namespace engine {
 
 
 /** This is inspired by the number of MIDI channels. */
-static const int PORT_MAX_CHANNELS = 16;
+static constexpr const int PORT_MAX_CHANNELS = 16;
 
 
 struct Port {

--- a/include/window/Svg.hpp
+++ b/include/window/Svg.hpp
@@ -13,8 +13,8 @@ namespace window {
 
 
 /** Arbitrary DPI, standardized for Rack. */
-static const float SVG_DPI = 75.f;
-static const float MM_PER_IN = 25.4f;
+static constexpr const float SVG_DPI = 75.f;
+static constexpr const float MM_PER_IN = 25.4f;
 
 
 /** Converts inch measurements to pixels */


### PR DESCRIPTION
Rack codebase uses C++11, for which `constexpr` is a part of.
Marking the constants as constexpr allows for their use in static members, where the value is calculated at build time.
Not only it helps with cpu usage (although fairly limited sure) but also simplifies the code quite a bit.

Consider the case of using `RACK_GRID_WIDTH` to automatically calculate the position of widgets on a module panel.
With the proposed changes, it allows us to use code like this:

```
struct DelayWidget : ModuleWidget {
	static constexpr const int kWidth = 9;
	static constexpr const float kBorderPadding = 5.f;
	static constexpr const float kUsableWidth = RACK_GRID_WIDTH * kWidth - kBorderPadding * 2.f;

	static constexpr const float kPosLeft = kBorderPadding + kUsableWidth * 0.25f;
	static constexpr const float kPosRight = kBorderPadding + kUsableWidth * 0.75f;
```

With this in place, and the knowledge of padding/borders and general position of widgets, teams can easily create both artwork and code for the panel at the same time.

Sure the same can still be done without `constexpr`, but never as nice.
It either requires placing the variables on a global namespace, or in separate definition / declaration.
Code with `constexpr` ends up looking much cleaner, and it is faster for runtime as well (compared to using global variables anyway).

Comments / opinions welcome.
