### PR TITLE
Compile .mm files with CXX rather than CC

### DIFF
--- a/compile.mk
+++ b/compile.mk
@@ -88,7 +88,7 @@ build/%.m.o: %.m
 
 build/%.mm.o: %.mm
 	@mkdir -p $(@D)
-	$(CC) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 build/%.bin.o: %
 	@mkdir -p $(@D)


### PR DESCRIPTION
otherwise compiling `src/asset.mm` fails with:

```
  src/asset.mm:1:9: fatal error: 'string' file not found
  #import <string>
```