### PR TITLE
Add call to glfwInitHint to enable rack to launch on Wayland

### DIFF
--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -819,6 +819,10 @@ void init() {
 	glfwInitHint(GLFW_COCOA_MENUBAR, GLFW_FALSE);
 #endif
 
+#if defined ARCH_LIN
+	glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_X11);
+#endif
+
 	glfwSetErrorCallback(errorCallback);
 	err = glfwInit();
 	if (err != GLFW_TRUE) {


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/393113#issuecomment-3184122450 has examples of users unable to launch Rack without workarounds

I have tried adding this line and Rack builds and runs successfully on a wayland-based desktop.